### PR TITLE
Fix Plus membership check (it's required according to terms of service)

### DIFF
--- a/watchteleboy
+++ b/watchteleboy
@@ -282,7 +282,7 @@ if ! wget \
     --output-document - \
     --load-cookies ${TMPPATH}/cookie1 \
     $URL | \
-    grep "Teleboy Plus" > /dev/null
+    grep "plusMember: 1," > /dev/null
 then
   $quiet || echo "failed (no Teleboy Plus)"
   echo "In order to comply with the terms of service of Teleboy" 1>&2


### PR DESCRIPTION
The string "Teleboy Plus" may likely appear on the site, even if one is not a plus member. (Not seen it, but who knows...)
I assume the proposed check will be less error prone.
