### PR TITLE
documented the --deleteme option

### DIFF
--- a/DOCS/man/watchteleboy.1
+++ b/DOCS/man/watchteleboy.1
@@ -73,6 +73,9 @@ be anything understood by the command
 .IP "\fB\-\-delete-cron CHANNEL TIME"
 Delete a previously scheduled job from crontab. To match exactly a 
 specific job you need to specify the CHANNEL and its start time TIME.
+.IP "\fB\-\-deleteme"
+Delete session files. After deletion of session files you will be logged
+in new and your local tv channel list will be updated.
 .IP "\fB\-h, \-\-help"
 Print a summary of available options and exit.
 .IP "\fB\-l, \-\-list"

--- a/watchteleboy
+++ b/watchteleboy
@@ -175,6 +175,7 @@ GENERAL OPTIONS:
   -c|--channel CHANNEL        specify a channel
   --delete-cron CHANNEL TIME  delete a previously scheduled job
   -d|--duration SECONDS	      specify the duration
+  --deleteme                  delete session cookies / logout
   -e|--endtime TIME           schedule the end time
   -h|--help                   show this help and exit
   -l|--list                   print a list of all channels and exit


### PR DESCRIPTION
i was searching for an option to log out (to update the local cached tv channel list). after looking through the source code i found the undocumented --deleteme option. i updated the --help documentation and the man page.